### PR TITLE
add rest button on the character sheet

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -20,6 +20,24 @@ export class IntoTheOddActorSheet extends ActorSheet {
   /* -------------------------------------------- */
 
   /** @override */
+  _getHeaderButtons() {
+    let buttons = super._getHeaderButtons();
+
+    if (this.actor.isOwner) {
+      buttons = [
+        {
+          label: 'Rest',
+          class: 'rest-up',
+          icon: 'fas fa-bed',
+          onclick: () => this._rest(),
+        },
+      ].concat(buttons);
+    }
+
+    return buttons;
+  }
+
+  /** @override */
   getData() {
     const context = super.getData();
     context.systemData = context.data.data;
@@ -110,4 +128,24 @@ export class IntoTheOddActorSheet extends ActorSheet {
     }
   }
 
+  _rest() {
+    let d = new Dialog({
+      title: 'Rest',
+      buttons: {
+        short: {
+          label: 'Short Rest',
+          callback: () => this.actor.rest(false),
+        },
+        full: {
+          label: 'Full Rest',
+          callback: () => this.actor.rest(true),
+        },
+      },
+      default: 'short',
+      close: () => {
+        this.render(false);
+      },
+    });
+    d.render(true);
+  }
 }

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -47,7 +47,17 @@ export class IntoTheOddActor extends Actor {
     if (item.data.data.quantity > 1) {
       item.data.data.quantity--;
     } else {
-      item.delete()
+      item.delete();
+    }
+  }
+
+  rest(full) {
+    this.system.hp.value = this.system.hp.max;
+
+    if (full) {
+      this.system.abilities.dex.value = this.system.abilities.dex.max;
+      this.system.abilities.str.value = this.system.abilities.str.max;
+      this.system.abilities.wil.value = this.system.abilities.wil.max;
     }
   }
 }


### PR DESCRIPTION
Implementation for #36 .

A single Rest button in the actor sheet menu bar that opens a dialog for short (only hp) or full rest (hp + stats).

<img width="502" alt="Screen Shot 2023-01-31 at 3 46 47 PM" src="https://user-images.githubusercontent.com/408380/215879433-5fafb681-22c2-48f5-ad74-c612b4bd5344.png">
<img width="496" alt="Screen Shot 2023-01-31 at 3 46 58 PM" src="https://user-images.githubusercontent.com/408380/215879471-1f5193ba-0c4f-47cb-9a52-c4542219147f.png">

@voidcase Let me know if you had something else in mind.
