### PR TITLE
Add link actor data on prototype token at creation

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -3,6 +3,22 @@
  * @extends {Actor}
  */
 export class IntoTheOddActor extends Actor {
+  /** @override */
+  static async create(data, options = {}) {
+    if (data.type === 'character') {
+      mergeObject(
+        data,
+        {
+          prototypeToken: {
+            disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
+            actorLink: true,
+          },
+        },
+        { override: false }
+      );
+    }
+    return super.create(data, options);
+  }
 
   /**
    * Augment the basic actor data with additional dynamic data.


### PR DESCRIPTION
We had a few issues when we started using the system as players started to edit they character from their token. Since the actor link is not enabled by at creation they ended up having to duplicate the changes on their character sheet.

I think most systems (or at least the one I used) activated it on creation, hence this PR.