### PR TITLE
update system.json to enable use in V11

### DIFF
--- a/system.json
+++ b/system.json
@@ -3,8 +3,10 @@
   "title": "Into the Odd",
   "description": "The Into the Odd system for FoundryVTT!",
   "version": "1.3.1",
-  "minimumCoreVersion": "0.6.2",
-  "compatibleCoreVersion": "10",
+  "compatibility": {
+    "minimum":  "0.6.2",
+    "verified": "10"
+  }
   "templateVersion": 2,
   "author": "voidcase",
   "esmodules": ["module/intotheodd.js"],
@@ -16,7 +18,7 @@
       "label": "Macros for playing Into the Odd",
       "system": "intotheodd",
       "path": "./packs/into-the-odd-macros.db",
-      "entity": "Macro"
+      "type": "Macro"
     }
   ],
   "languages": [],

--- a/system.json
+++ b/system.json
@@ -6,7 +6,7 @@
   "compatibility": {
     "minimum":  "0.6.2",
     "verified": "10"
-  }
+  },
   "templateVersion": 2,
   "author": "voidcase",
   "esmodules": ["module/intotheodd.js"],


### PR DESCRIPTION
in order to get this working on V11, i needed to update the way compatibility was specified in `system.json` and rename the `entity` field in the `packs` to `type`.